### PR TITLE
switch to opam2, add opam init

### DIFF
--- a/Makefile.mirage
+++ b/Makefile.mirage
@@ -31,26 +31,19 @@ update-repo:
 dist-prep:
 	@true
 
-.PHONY: install-opam
 install-opam2:
 	curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -o $(CACHEDIR)/opam-install.sh
 	sha256sum $(CACHEDIR)/opam-install.sh
 	yes '' | sh $(CACHEDIR)/opam-install.sh
 
-install-opam:
-	curl https://raw.githubusercontent.com/ocaml/opam/1.2/shell/opam_installer.sh -o $(CACHEDIR)/opam_installer.sh
-	sha256sum $(CACHEDIR)/opam_installer.sh
-	exec 9>&2 && \
-	export OPAMFETCH_LOG_FD=9 && \
-	sh $(CACHEDIR)/opam_installer.sh /usr/local/bin $(OCAML_VERSION)
-
-dist-prepare-chroot: $(shell command -v opam >/dev/null || echo install-opam)
-	@true
+dist-prepare-chroot: $(shell command -v opam >/dev/null || echo install-opam2)
+	opam init -y
 
 opam-switch-%:
 	exec 9>&2 && \
 	export OPAMFETCH_LOG_FD=9 && \
-	opam switch set -A $(OCAML_VERSION) $*
+	opam switch set $* || \
+	opam switch create $* $(OCAML_VERSION)
 
 dist-build-dep: $(SOURCE_BUILD_DEP)
 dist-build-dep: opam-switch-$(COMPONENT)

--- a/Makefile.mirage
+++ b/Makefile.mirage
@@ -26,7 +26,7 @@ OCAML_VERSION ?= system
 OPAMFETCH := $(MIRAGE_PLUGIN_DIR)/scripts/download-and-log %{url}% %{out}% md5 %{checksum}%
 
 update-repo:
-	cp $(BUILDER_REPO_DIR)/$(COMPONENT).xen $(UPDATE_REPO)/
+	cp $(BUILDER_REPO_DIR)/$(TEMPLATE_FLAVOR).xen $(UPDATE_REPO)/
 
 dist-prep:
 	@true


### PR DESCRIPTION
removed opam1 support since it is a dead-end.
f.ex. even the new version of opam-depext with your --whatprovides fix for building on fedora depends on opam2.

i am not fully happy with the amount of harmless but confusing verbose chatter that is created, but dont have a good idea on how to improve it.
- redundant calls to opam init (should only be called if there is no ~/.opam +/- chroot) 
- the set-or-create for the switches

but it works!
and builds both mirage-firewall and mirage-ssh-agent kernels