### PR TITLE
update opam repo after (redundant) init

### DIFF
--- a/Makefile.mirage
+++ b/Makefile.mirage
@@ -38,6 +38,7 @@ install-opam2:
 
 dist-prepare-chroot: $(shell command -v opam >/dev/null || echo install-opam2)
 	opam init -y
+	opam update -y
 
 opam-switch-%:
 	exec 9>&2 && \


### PR DESCRIPTION
workaround for yet another flavor of opam pkg dependency deadlock