### PR TITLE
add OCAML_VERSION to opam switch name

### DIFF
--- a/Makefile.mirage
+++ b/Makefile.mirage
@@ -43,8 +43,8 @@ dist-prepare-chroot: $(shell command -v opam >/dev/null || echo install-opam2)
 opam-switch-%:
 	exec 9>&2 && \
 	export OPAMFETCH_LOG_FD=9 && \
-	opam switch set $* || \
-	opam switch create $* $(OCAML_VERSION)
+	opam switch set $*-$(OCAML_VERSION) || \
+	opam switch create $*-$(OCAML_VERSION) $(OCAML_VERSION)
 
 dist-build-dep: $(SOURCE_BUILD_DEP)
 dist-build-dep: opam-switch-$(COMPONENT)


### PR DESCRIPTION
so we start with a clean switch when changing compilers