### PR TITLE
change default grub timeout from 1 to 0

### DIFF
--- a/template_scripts/grub.cfg
+++ b/template_scripts/grub.cfg
@@ -1,4 +1,4 @@
-set timeout=1
+set timeout=0
 menuentry default {
     set root="(hd0)"
 	multiboot /boot/kernel

--- a/template_scripts/menu.lst
+++ b/template_scripts/menu.lst
@@ -1,5 +1,5 @@
 default 0
-timeout 1
+timeout 0
 title Mirage
   root (hd0)
   kernel /boot/kernel


### PR DESCRIPTION
this improves the "major usecase" of "i just want to boot it asap".
if something goes wrong it will still ask for holding hands, and anyone who feels the need to customize their pvgrub experience can still trivially do so.