### PR TITLE
prefix version string on switch create to avoid version collisions

### DIFF
--- a/Makefile.mirage
+++ b/Makefile.mirage
@@ -44,7 +44,7 @@ opam-switch-%:
 	exec 9>&2 && \
 	export OPAMFETCH_LOG_FD=9 && \
 	opam switch set $*-$(OCAML_VERSION) || \
-	opam switch create $*-$(OCAML_VERSION) $(OCAML_VERSION)
+	opam switch create $*-$(OCAML_VERSION) ocaml-base-compiler.$(OCAML_VERSION)
 
 dist-build-dep: $(SOURCE_BUILD_DEP)
 dist-build-dep: opam-switch-$(COMPONENT)


### PR DESCRIPTION
this is needed for the special situation like using ocaml 10.0.1 on fedora-32 (which ships ocaml 10.0.1 as system-ocaml) so opam knows we want it to use a custom built ocaml anyways.

(and as usual, i can not remember whether pinging @marmarek is required here. ;)